### PR TITLE
chore: release strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ as Frax deposits also can be locked for increased time periods for higher APR (m
 (called `keks` by Frax), and can also be configured to redeposit to the same keks over and over, meaning that past the initial 7-day period there
 is effectively no lock.
 
+### [StrategyPrismaConvexFactoryClonable.sol](https://github.com/dudesahn/CurveVaultFactory/blob/main/contracts/StrategyPrismaConvexFactoryClonable.sol)
+
+Our Prisma Convex strategy is very similar to the Convex strategy, except we receive extra yield through Prisma's _receiver_ contract, which is
+their name for a gauge. vePRISMA voters are able to approve proposed receivers to receive vePRISMA emissions. For this strategy, we deposit the
+Curve LP to the Prisma Convex receiver, which just deposits to Convex via a Prisma contract and then receives extra vePRISMA (as yPRISMA) on top.
+Note that for most of these pools, PRISMA emissions are the primary form of yield, so for these vaults we will send the majority of `debtRatio` (if
+not 100%) to this strategy.
+
 ### [KeeperWrapper.sol](https://github.com/dudesahn/CurveVaultFactory/blob/main/contracts/KeeperWrapper.sol)
 
 If set as the keeper of the strategy, this contract will make harvest public. Factory harvests do not swap atomically,

--- a/contracts/StrategyConvexFactoryClonable.sol
+++ b/contracts/StrategyConvexFactoryClonable.sol
@@ -65,6 +65,9 @@ contract StrategyConvexFactoryClonable is BaseStrategy {
     /// @notice Will only be true on the original deployed contract and not on clones; we dont want to clone a clone.
     bool public isOriginal = true;
 
+    /// @notice Used to track the deployed version of this contract. Maps to releases in the CurveVaultFactory repo.
+    string public constant strategyVersion = "3.0.2";
+
     /* ========== CONSTRUCTOR ========== */
 
     constructor(

--- a/contracts/StrategyConvexFraxFactoryClonable.sol
+++ b/contracts/StrategyConvexFraxFactoryClonable.sol
@@ -117,8 +117,8 @@ contract StrategyConvexFraxFactoryClonable is BaseStrategy {
     /// @notice Info about our keks. See struct NatSpec for more details.
     KekInfo public kekInfo;
 
-    /// @notice Used to track the deployed version of this contract.
-    string public constant strategyVersion = "2.1.0";
+    /// @notice Used to track the deployed version of this contract. Maps to releases in the CurveVaultFactory repo.
+    string public constant strategyVersion = "3.0.2";
 
     /* ========== CONSTRUCTOR ========== */
 

--- a/contracts/StrategyCurveBoostedFactoryClonable.sol
+++ b/contracts/StrategyCurveBoostedFactoryClonable.sol
@@ -7,6 +7,7 @@ import "./interfaces/CurveInterfaces.sol";
 
 contract StrategyCurveBoostedFactoryClonable is BaseStrategy {
     using SafeERC20 for IERC20;
+
     /* ========== STATE VARIABLES ========== */
 
     /// @notice Yearns strategyProxy, needed for interacting with our Curve Voter.
@@ -37,6 +38,9 @@ contract StrategyCurveBoostedFactoryClonable is BaseStrategy {
 
     /// @notice Will only be true on the original deployed contract and not on clones; we dont want to clone a clone.
     bool public isOriginal = true;
+
+    /// @notice Used to track the deployed version of this contract. Maps to releases in the CurveVaultFactory repo.
+    string public constant strategyVersion = "3.0.2";
 
     /* ========== CONSTRUCTOR ========== */
 

--- a/contracts/StrategyPrismaConvexFactoryClonable.sol
+++ b/contracts/StrategyPrismaConvexFactoryClonable.sol
@@ -71,8 +71,8 @@ contract StrategyPrismaConvexFactoryClonable is BaseStrategy {
     /// @notice Will only be true on the original deployed contract and not on clones; we dont want to clone a clone.
     bool public isOriginal = true;
 
-    /// @notice Used to track the deployed version of this contract.
-    string public constant strategyVersion = "3.0.1";
+    /// @notice Used to track the deployed version of this contract. Maps to releases in the CurveVaultFactory repo.
+    string public constant strategyVersion = "3.0.2";
 
     /* ========== CONSTRUCTOR ========== */
 


### PR DESCRIPTION
* add `strategyVersion` string to curve, convex strats and bump version for Frax. Core updates since [v2.1.0](https://github.com/dudesahn/CurveVaultFactory/tree/v2.1.0) include formatting and moving interfaces to a separate contract
* update README for Prisma strategy 